### PR TITLE
[BUGFIX] Current user null return when unauthenticated

### DIFF
--- a/src/main/java/com/team25/event/planner/user/service/CurrentUserService.java
+++ b/src/main/java/com/team25/event/planner/user/service/CurrentUserService.java
@@ -23,6 +23,8 @@ public class CurrentUserService {
     }
 
     public User getCurrentUser() {
+        final Long currentUserId = getCurrentUserId();
+        if(currentUserId == null) return null;
         return userRepository.findById(getCurrentUserId()).orElse(null);
     }
 }


### PR DESCRIPTION
Current user service threw an error instead of returning null when the user was not logged in.