### PR TITLE
[ADD] Java Mail Sender

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,10 @@
 			<version>7.0.1</version>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
 			<version>5.9.0</version>

--- a/src/main/java/com/team25/event/planner/config/JavaMailSenderConfig.java
+++ b/src/main/java/com/team25/event/planner/config/JavaMailSenderConfig.java
@@ -1,0 +1,9 @@
+package com.team25.event.planner.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(JavaMailSenderConfigProperties.class)
+public class JavaMailSenderConfig {
+}

--- a/src/main/java/com/team25/event/planner/config/JavaMailSenderConfigProperties.java
+++ b/src/main/java/com/team25/event/planner/config/JavaMailSenderConfigProperties.java
@@ -1,0 +1,21 @@
+package com.team25.event.planner.config;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "java.email.config")
+public class JavaMailSenderConfigProperties {
+    @Email
+    @NotBlank
+    private String fromEmail;
+
+    @NotBlank
+    private String fromName;
+}

--- a/src/main/java/com/team25/event/planner/infrastructure/JavaMailSenderEmailSenderService.java
+++ b/src/main/java/com/team25/event/planner/infrastructure/JavaMailSenderEmailSenderService.java
@@ -1,0 +1,40 @@
+package com.team25.event.planner.infrastructure;
+
+import com.team25.event.planner.config.JavaMailSenderConfigProperties;
+import com.team25.event.planner.email.dto.EmailDTO;
+import com.team25.event.planner.email.exception.EmailSendFailedException;
+import com.team25.event.planner.email.service.EmailSenderService;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import java.io.UnsupportedEncodingException;
+
+@Primary
+@Service
+@RequiredArgsConstructor
+public class JavaMailSenderEmailSenderService implements EmailSenderService {
+    private final JavaMailSenderConfigProperties config;
+    private final JavaMailSender mailSender;
+
+    @Override
+    public void sendEmail(EmailDTO email) throws EmailSendFailedException {
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message);
+
+        try {
+            helper.setFrom(config.getFromEmail(), config.getFromName());
+            helper.setTo(email.getRecipientEmail());
+            helper.setSubject(email.getSubject());
+            helper.setText(email.getBody(), true);
+        } catch (MessagingException | UnsupportedEncodingException e) {
+            throw new EmailSendFailedException(e.getMessage());
+        }
+
+        mailSender.send(message);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -57,3 +57,12 @@ spring.config.import=classpath:routes.yml
 
 greeting.cron=0 * * * * *
 
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=event.planner.team25@gmail.com
+spring.mail.password=
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+
+java.email.config.from-email=event.planner.team25@gmail.com
+java.email.config.from-name=Event Planner


### PR DESCRIPTION
Added another implementation of `EmailSenderService` using `JavaMailSender`.

This one does not require third party set up with Sendgrid and avoids all the complications that go along with that. 